### PR TITLE
harsilspatel/overlayed

### DIFF
--- a/CameraOverlay/.env
+++ b/CameraOverlay/.env
@@ -1,0 +1,1 @@
+MHP_CAMERA=primary

--- a/CameraOverlay/.env
+++ b/CameraOverlay/.env
@@ -1,1 +1,0 @@
-MHP_CAMERA=primary

--- a/CameraOverlay/Overlay_Demo.py
+++ b/CameraOverlay/Overlay_Demo.py
@@ -5,6 +5,7 @@ import time
 import datetime as dt
 import paho.mqtt.client as mqtt
 import json
+import commons
 
 speed_height = 70
 speed_font = ImageFont.truetype('/usr/share/fonts/truetype/freefont/FreeSans.ttf',speed_height)
@@ -72,6 +73,7 @@ def on_connect(client, userdata, flags, rc):
     client.subscribe("stop")
     client.subscribe("power_model/recommended_SP")
     client.subscribe("power_model/max_speed")
+    client.subscribe("camera/get_overlays")
 
     # Add static text
     img = Image.new('RGBA', (WIDTH, HEIGHT))
@@ -100,6 +102,9 @@ def on_message(client, userdata, msg):
     elif msg.topic == "power_model/max_speed":
         max_speed = str(msg.payload.decode("utf-8"))
         POWER_MODEL_DATA["max_speed"] = float(max_speed)
+    elif msg.topic == "camera/get_overlays":
+        overlays = commons.get_overlays()
+        client.publish("camera/push_overlays", json.dumps(overlays))
     elif msg.topic == "data":
         data = str(msg.payload.decode("utf-8"))
         parsed_data = parse_data(data)

--- a/CameraOverlay/Overlay_Demo.py
+++ b/CameraOverlay/Overlay_Demo.py
@@ -73,8 +73,6 @@ def on_connect(client, userdata, flags, rc):
     client.subscribe("stop")
     client.subscribe("power_model/recommended_SP")
     client.subscribe("power_model/max_speed")
-    client.subscribe("camera/get_overlays")
-    client.subscribe("camera/set_overlay")
 
     # Add static text
     img = Image.new('RGBA', (WIDTH, HEIGHT))
@@ -103,11 +101,6 @@ def on_message(client, userdata, msg):
     elif msg.topic == "power_model/max_speed":
         max_speed = str(msg.payload.decode("utf-8"))
         POWER_MODEL_DATA["max_speed"] = float(max_speed)
-    elif msg.topic == "camera/get_overlays":
-        configs = commons.read_configs()
-        client.publish("camera/push_overlays", json.dumps(configs))
-    elif msg.topic == "camera/set_overlay":
-        commons.set_overlay(json.loads(str(msg.payload.decode("utf-8"))))
     elif msg.topic == "data":
         data = str(msg.payload.decode("utf-8"))
         parsed_data = parse_data(data)

--- a/CameraOverlay/Overlay_Demo.py
+++ b/CameraOverlay/Overlay_Demo.py
@@ -2,10 +2,7 @@
 from picamera import PiCamera, Color
 from PIL import Image, ImageDraw, ImageFont
 import time
-import datetime as dt
 import paho.mqtt.client as mqtt
-import json
-import commons
 
 speed_height = 70
 speed_font = ImageFont.truetype('/usr/share/fonts/truetype/freefont/FreeSans.ttf',speed_height)

--- a/CameraOverlay/Overlay_Demo.py
+++ b/CameraOverlay/Overlay_Demo.py
@@ -74,6 +74,7 @@ def on_connect(client, userdata, flags, rc):
     client.subscribe("power_model/recommended_SP")
     client.subscribe("power_model/max_speed")
     client.subscribe("camera/get_overlays")
+    client.subscribe("camera/set_overlay")
 
     # Add static text
     img = Image.new('RGBA', (WIDTH, HEIGHT))
@@ -105,6 +106,8 @@ def on_message(client, userdata, msg):
     elif msg.topic == "camera/get_overlays":
         overlays = commons.get_overlays()
         client.publish("camera/push_overlays", json.dumps(overlays))
+    elif msg.topic == "camera/set_overlay":
+        commons.set_overlay(str(msg.payload.decode("utf-8")))
     elif msg.topic == "data":
         data = str(msg.payload.decode("utf-8"))
         parsed_data = parse_data(data)

--- a/CameraOverlay/Overlay_Demo.py
+++ b/CameraOverlay/Overlay_Demo.py
@@ -107,7 +107,7 @@ def on_message(client, userdata, msg):
         configs = commons.read_configs()
         client.publish("camera/push_overlays", json.dumps(configs))
     elif msg.topic == "camera/set_overlay":
-        commons.set_overlay(str(msg.payload.decode("utf-8")))
+        commons.set_overlay(json.loads(str(msg.payload.decode("utf-8"))))
     elif msg.topic == "data":
         data = str(msg.payload.decode("utf-8"))
         parsed_data = parse_data(data)

--- a/CameraOverlay/Overlay_Demo.py
+++ b/CameraOverlay/Overlay_Demo.py
@@ -104,8 +104,8 @@ def on_message(client, userdata, msg):
         max_speed = str(msg.payload.decode("utf-8"))
         POWER_MODEL_DATA["max_speed"] = float(max_speed)
     elif msg.topic == "camera/get_overlays":
-        overlays = commons.get_overlays()
-        client.publish("camera/push_overlays", json.dumps(overlays))
+        configs = commons.read_configs()
+        client.publish("camera/push_overlays", json.dumps(configs))
     elif msg.topic == "camera/set_overlay":
         commons.set_overlay(str(msg.payload.decode("utf-8")))
     elif msg.topic == "data":

--- a/CameraOverlay/Overlay_Demo2.py
+++ b/CameraOverlay/Overlay_Demo2.py
@@ -76,8 +76,6 @@ def on_connect(client, userdata, flags, rc):
     client.subscribe("power_model/recommended_SP")
     client.subscribe("power_model/predicted_max_speed")
     client.subscribe("power_model/plan_name")
-    client.subscribe("camera/get_overlays")
-    client.subscribe("camera/set_overlay")
 
     # Add static text
     img = Image.new('RGBA', (WIDTH, HEIGHT))
@@ -107,11 +105,6 @@ def on_message(client, userdata, msg):
         pred_max_speed = str(msg.payload.decode("utf-8"))
         parsed_data = parse_data(pred_max_speed)
         POWER_MODEL_DATA["pred_max_speed"] = int(parsed_data["predicted_max_speed"])
-    elif msg.topic == "camera/get_overlays":
-        configs = commons.read_configs()
-        client.publish("camera/push_overlays", json.dumps(configs))
-    elif msg.topic == "camera/set_overlay":
-        commons.set_overlay(json.loads(str(msg.payload.decode("utf-8"))))
     elif msg.topic == "power_model/plan_name":
         plan_name = str(msg.payload.decode("utf-8"))
         parsed_data = parse_data(plan_name)

--- a/CameraOverlay/Overlay_Demo2.py
+++ b/CameraOverlay/Overlay_Demo2.py
@@ -3,10 +3,7 @@
 from picamera import PiCamera, Color
 from PIL import Image, ImageDraw, ImageFont
 import time
-import datetime as dt
 import paho.mqtt.client as mqtt
-import json
-import commons
 
 # Resolution of camera preview
 WIDTH = 1280

--- a/CameraOverlay/Overlay_Demo2.py
+++ b/CameraOverlay/Overlay_Demo2.py
@@ -111,7 +111,7 @@ def on_message(client, userdata, msg):
         configs = commons.read_configs()
         client.publish("camera/push_overlays", json.dumps(configs))
     elif msg.topic == "camera/set_overlay":
-        commons.set_overlay(str(msg.payload.decode("utf-8")))
+        commons.set_overlay(json.loads(str(msg.payload.decode("utf-8"))))
     elif msg.topic == "power_model/plan_name":
         plan_name = str(msg.payload.decode("utf-8"))
         parsed_data = parse_data(plan_name)

--- a/CameraOverlay/Overlay_Demo2.py
+++ b/CameraOverlay/Overlay_Demo2.py
@@ -77,6 +77,7 @@ def on_connect(client, userdata, flags, rc):
     client.subscribe("power_model/predicted_max_speed")
     client.subscribe("power_model/plan_name")
     client.subscribe("camera/get_overlays")
+    client.subscribe("camera/set_overlay")
 
     # Add static text
     img = Image.new('RGBA', (WIDTH, HEIGHT))
@@ -109,6 +110,8 @@ def on_message(client, userdata, msg):
     elif msg.topic == "camera/get_overlays":
         overlays = commons.get_overlays()
         client.publish("camera/push_overlays", json.dumps(overlays))
+    elif msg.topic == "camera/set_overlay":
+        commons.set_overlay(str(msg.payload.decode("utf-8")))
     elif msg.topic == "power_model/plan_name":
         plan_name = str(msg.payload.decode("utf-8"))
         parsed_data = parse_data(plan_name)

--- a/CameraOverlay/Overlay_Demo2.py
+++ b/CameraOverlay/Overlay_Demo2.py
@@ -6,6 +6,7 @@ import time
 import datetime as dt
 import paho.mqtt.client as mqtt
 import json
+import commons
 
 # Resolution of camera preview
 WIDTH = 1280
@@ -75,6 +76,7 @@ def on_connect(client, userdata, flags, rc):
     client.subscribe("power_model/recommended_SP")
     client.subscribe("power_model/predicted_max_speed")
     client.subscribe("power_model/plan_name")
+    client.subscribe("camera/get_overlays")
 
     # Add static text
     img = Image.new('RGBA', (WIDTH, HEIGHT))
@@ -104,6 +106,9 @@ def on_message(client, userdata, msg):
         pred_max_speed = str(msg.payload.decode("utf-8"))
         parsed_data = parse_data(pred_max_speed)
         POWER_MODEL_DATA["pred_max_speed"] = int(parsed_data["predicted_max_speed"])
+    elif msg.topic == "camera/get_overlays":
+        overlays = commons.get_overlays()
+        client.publish("camera/push_overlays", json.dumps(overlays))
     elif msg.topic == "power_model/plan_name":
         plan_name = str(msg.payload.decode("utf-8"))
         parsed_data = parse_data(plan_name)

--- a/CameraOverlay/Overlay_Demo2.py
+++ b/CameraOverlay/Overlay_Demo2.py
@@ -108,8 +108,8 @@ def on_message(client, userdata, msg):
         parsed_data = parse_data(pred_max_speed)
         POWER_MODEL_DATA["pred_max_speed"] = int(parsed_data["predicted_max_speed"])
     elif msg.topic == "camera/get_overlays":
-        overlays = commons.get_overlays()
-        client.publish("camera/push_overlays", json.dumps(overlays))
+        configs = commons.read_configs()
+        client.publish("camera/push_overlays", json.dumps(configs))
     elif msg.topic == "camera/set_overlay":
         commons.set_overlay(str(msg.payload.decode("utf-8")))
     elif msg.topic == "power_model/plan_name":

--- a/CameraOverlay/commons.py
+++ b/CameraOverlay/commons.py
@@ -6,7 +6,7 @@ CURRENT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
 
 def get_overlays(dir=CURRENT_DIRECTORY):
-	overlays = [file for file in os.listdir(dir) if fnmatch.fnmatch(file, OVERLAY_FILE_PATTERN)]
+	overlays = [os.path.basename(file) for file in os.listdir(dir) if fnmatch.fnmatch(file, OVERLAY_FILE_PATTERN)]
 	return overlays
 
 if __name__ == '__main__':

--- a/CameraOverlay/commons.py
+++ b/CameraOverlay/commons.py
@@ -13,6 +13,8 @@ def set_overlay(new_overlays, dir=CURRENT_DIRECTORY):
 	new_overlay = new_overlays[current_device]
 
 	configs = read_configs(dir)
+	if 'device' in configs:
+		configs.pop('device')
 	configs[ACTIVE_OVERLAY_KEY] = new_overlay
 
 	with open(os.path.join(dir, CONFIG_FILE), 'w') as f:
@@ -35,6 +37,6 @@ def get_active_overlay(dir=CURRENT_DIRECTORY):
 	return os.path.join(dir, configs[ACTIVE_OVERLAY_KEY])
 
 if __name__ == '__main__':
-	set_overlay('Overlay_Demo2.py')
+	set_overlay({'primary': 'Overlay_Demo2.py'})
 	print(get_active_overlay())
 	print(read_configs())

--- a/CameraOverlay/commons.py
+++ b/CameraOverlay/commons.py
@@ -1,29 +1,37 @@
 import os
 import json
-import fnmatch
+from dotenv import load_dotenv
 
+load_dotenv()
 CONFIG_FILE = 'configs.json'
 ACTIVE_OVERLAY_KEY = 'activeOverlay'
-OVERLAY_FILE_PATTERN = 'Overlay_Demo*.py'
 CURRENT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
 
-def get_overlays(dir=CURRENT_DIRECTORY):
-	overlays = [os.path.basename(file) for file in os.listdir(dir) if fnmatch.fnmatch(file, OVERLAY_FILE_PATTERN)]
-	return overlays
-
-
 def set_overlay(overlay, dir=CURRENT_DIRECTORY):
+	configs = read_configs(dir)
+	configs[ACTIVE_OVERLAY_KEY] = overlay
+
 	with open(os.path.join(dir, CONFIG_FILE), 'w') as f:
-		json.dump({ACTIVE_OVERLAY_KEY: overlay}, f, indent=2)
+		json.dump(configs, f, indent=2, sort_keys=True)
+
+def read_configs(dir=CURRENT_DIRECTORY):
+	filepath = os.path.join(dir, CONFIG_FILE)
+	if not os.path.isfile(filepath):
+		return {}
+	else:
+		with open(filepath) as f:
+			configs = json.load(f)
+
+			current_device = os.getenv('MHP_CAMERA')
+			configs['device'] = current_device
+			return configs
 
 def get_active_overlay(dir=CURRENT_DIRECTORY):
-	with open(os.path.join(dir, CONFIG_FILE)) as f:
-		data = json.load(f)
-		active_overlay = data[ACTIVE_OVERLAY_KEY]
-		return os.path.join(dir, active_overlay)
+	configs = read_configs(dir)
+	return os.path.join(dir, configs[ACTIVE_OVERLAY_KEY])
 
 if __name__ == '__main__':
-	print(get_overlays())
-	set_overlay('bleh bleh bleh')
+	set_overlay('Overlay_Demo2.py')
 	print(get_active_overlay())
+	print(read_configs())

--- a/CameraOverlay/commons.py
+++ b/CameraOverlay/commons.py
@@ -1,4 +1,5 @@
 import os
+import json
 import fnmatch
 
 OVERLAY_FILE_PATTERN = 'Overlay_Demo*.py'
@@ -9,5 +10,12 @@ def get_overlays(dir=CURRENT_DIRECTORY):
 	overlays = [os.path.basename(file) for file in os.listdir(dir) if fnmatch.fnmatch(file, OVERLAY_FILE_PATTERN)]
 	return overlays
 
+
+def set_overlay(overlay, dir=CURRENT_DIRECTORY):
+	with open(os.path.join(dir, 'configs.json'), 'w') as f:
+		json.dump({'activeOverlay': overlay}, f, indent=2)
+
+
 if __name__ == '__main__':
-    print(get_overlays('./CameraOverlay/'))
+	print(get_overlays())
+	set_overlay('test')

--- a/CameraOverlay/commons.py
+++ b/CameraOverlay/commons.py
@@ -2,6 +2,8 @@ import os
 import json
 import fnmatch
 
+CONFIG_FILE = 'configs.json'
+ACTIVE_OVERLAY_KEY = 'activeOverlay'
 OVERLAY_FILE_PATTERN = 'Overlay_Demo*.py'
 CURRENT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
@@ -12,10 +14,16 @@ def get_overlays(dir=CURRENT_DIRECTORY):
 
 
 def set_overlay(overlay, dir=CURRENT_DIRECTORY):
-	with open(os.path.join(dir, 'configs.json'), 'w') as f:
-		json.dump({'activeOverlay': overlay}, f, indent=2)
+	with open(os.path.join(dir, CONFIG_FILE), 'w') as f:
+		json.dump({ACTIVE_OVERLAY_KEY: overlay}, f, indent=2)
 
+def get_active_overlay(dir=CURRENT_DIRECTORY):
+	with open(os.path.join(dir, CONFIG_FILE)) as f:
+		data = json.load(f)
+		active_overlay = data[ACTIVE_OVERLAY_KEY]
+		return os.path.join(dir, active_overlay)
 
 if __name__ == '__main__':
 	print(get_overlays())
-	set_overlay('test')
+	set_overlay('bleh bleh bleh')
+	print(get_active_overlay())

--- a/CameraOverlay/commons.py
+++ b/CameraOverlay/commons.py
@@ -1,0 +1,13 @@
+import os
+import fnmatch
+
+OVERLAY_FILE_PATTERN = 'Overlay_Demo*.py'
+CURRENT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
+
+
+def get_overlays(dir=CURRENT_DIRECTORY):
+	overlays = [file for file in os.listdir(dir) if fnmatch.fnmatch(file, OVERLAY_FILE_PATTERN)]
+	return overlays
+
+if __name__ == '__main__':
+    print(get_overlays('./CameraOverlay/'))

--- a/CameraOverlay/commons.py
+++ b/CameraOverlay/commons.py
@@ -8,9 +8,12 @@ ACTIVE_OVERLAY_KEY = 'activeOverlay'
 CURRENT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
 
-def set_overlay(overlay, dir=CURRENT_DIRECTORY):
+def set_overlay(new_overlays, dir=CURRENT_DIRECTORY):
+	current_device = os.getenv('MHP_CAMERA')
+	new_overlay = new_overlays[current_device]
+
 	configs = read_configs(dir)
-	configs[ACTIVE_OVERLAY_KEY] = overlay
+	configs[ACTIVE_OVERLAY_KEY] = new_overlay
 
 	with open(os.path.join(dir, CONFIG_FILE), 'w') as f:
 		json.dump(configs, f, indent=2, sort_keys=True)

--- a/CameraOverlay/configs.json
+++ b/CameraOverlay/configs.json
@@ -1,6 +1,5 @@
 {
   "activeOverlay": "Overlay_Demo2.py",
-  "device": "primary",
   "overlays": [
     {
       "file": "Overlay_Demo.py",

--- a/CameraOverlay/configs.json
+++ b/CameraOverlay/configs.json
@@ -1,0 +1,14 @@
+{
+  "activeOverlay": "Overlay_Demo2.py",
+  "device": "primary",
+  "overlays": [
+    {
+      "file": "Overlay_Demo.py",
+      "name": "My first overlay"
+    },
+    {
+      "file": "Overlay_Demo2.py",
+      "name": "My second overlay"
+    }
+  ]
+}

--- a/CameraOverlay/orchestrator.py
+++ b/CameraOverlay/orchestrator.py
@@ -1,0 +1,47 @@
+import json
+import commons
+import paho.mqtt.client as mqtt
+
+brokerIP = "192.168.100.100"
+
+# The callback for when the client receives a CONNACK response from the server.
+def on_connect(client, userdata, flags, rc):
+    print("Connected with result code "+str(rc))
+
+    # Subscribing in on_connect() means that if we lose the connection and
+    # reconnect then subscriptions will be renewed.
+    client.subscribe("camera/set_overlay")
+    client.subscribe("camera/get_overlays")
+
+# The callback for when a PUBLISH message is received from the server.
+def on_message(client, userdata, msg):
+    print(msg.topic+" "+str(msg.payload))
+    if msg.topic == "camera/get_overlays":
+        configs = commons.read_configs()
+        client.publish("camera/push_overlays", json.dumps(configs))
+    elif msg.topic == "camera/set_overlay":
+        commons.set_overlay(json.loads(str(msg.payload.decode("utf-8"))))
+
+
+def on_log(client, userdata, level, buf):
+    print("\nlog: ", buf)
+
+
+def on_disconnect(client, userdata, msg):
+    print("Disconnected from broker")
+
+
+client = mqtt.Client()
+client.on_connect = on_connect
+client.on_message = on_message
+client.on_log = on_log
+client.on_disconnect = on_disconnect
+
+
+client.connect_async(brokerIP, 1883, 60)
+
+# Blocking call that processes network traffic, dispatches callbacks and
+# handles reconnecting.
+# Other loop*() functions are available that give a threaded interface and a
+# manual interface.
+client.loop_start()

--- a/CameraOverlay/orchestrator.py
+++ b/CameraOverlay/orchestrator.py
@@ -1,8 +1,14 @@
 import json
 import commons
+import argparse
 import paho.mqtt.client as mqtt
 
-brokerIP = "192.168.100.100"
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--host", type=str, default="192.168.100.100", help="ip address of the broker")
+args = parser.parse_args()
+
+brokerIP = args.host
 
 # The callback for when the client receives a CONNACK response from the server.
 def on_connect(client, userdata, flags, rc):

--- a/CameraOverlay/switch_demo.py
+++ b/CameraOverlay/switch_demo.py
@@ -1,6 +1,7 @@
 import RPi.GPIO as gpio
 from time import sleep
 import subprocess
+import commons
 
 # Pins
 switch = 15
@@ -34,7 +35,7 @@ try:
 			sleep(0.25)
 		prev_switch_state = switch_state
         # TODO: Remove hard coding of directory of python script
-		p1 = subprocess.Popen(["python3", "/home/pi/Documents/MHP_Raspicam/CameraOverlay/Overlay_Demo.py"])
+		p1 = subprocess.Popen(["python3", commons.get_active_overlay()])
 		turn_off(red_led)
 		turn_on(green_led)
 		sleep(1)

--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ To install Pillow (PIL fork), RPi.GPIO, paho-mqtt on Raspberry Pi: **haven't tes
     source venv/bin/activate   
     ````
   - install python dependencies `pip3 install -r requirements.txt`
+  - have an ```.env``` file in the ```CameraOverlay``` folder with the variable ```MHP_CAMERA``` set to either ```primary``` or ```secondary```
   - PROFIT!

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ paho-mqtt==1.4.0
 picamera==1.13
 Pillow==6.0.0
 RPi.GPIO==0.6.5
+python-dotenv==0.10.3


### PR DESCRIPTION
- an environment file for setting the MHP_CAMERA. we could've also configured this in the configs.json, however, this is more convenient if we just need to know the current device without reading the whole config file.
- methods to retrieve and set different overlays on both the screens.
- subscribing and publishing to the relevant topics (documented on the MQTT Topics document) for sending the list of overlays (with active overlay) and setting a new active overlay.
- update the switch script to read the current active overlay